### PR TITLE
Updated with the correct API URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Clojure library for retrieving data from the [forecast.io](https://developer.d
 `forecast-clojure` is available as a Maven artifact from [Clojars](http://clojars.org/forecast-clojure):
 
 ```clojure
-[forecast-clojure "1.0.3"]
+[forecast-clojure "1.0.4"]
 ```
 
 ## Configuration

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject forecast-clojure "1.0.3"
+(defproject forecast-clojure "1.0.4"
   :description "Clojure library for retrieving data from the Forecast API"
   :url "https://github.com/jdhollis/forecast-clojure"
   :license {:name "Eclipse Public License"

--- a/src/forecast_clojure/core.clj
+++ b/src/forecast_clojure/core.clj
@@ -7,7 +7,7 @@
 (defn forecast
   "Retrieve the forecast for a given latitude and longitude"
   [lat lon & {:keys [params time]}]
-  (let [base-url "https://api.forecast.io/forecast"
+  (let [base-url "https://api.darksky.net/forecast"
         api-key (env :forecast-key)
         url (join "/" [base-url api-key (join "," (filter #(not-empty %) (map str [lat lon time])))])
         response (client/get url {:query-params params :throw-exceptions false})]


### PR DESCRIPTION
Dark Sky have changed the default URL of their API which started throwing an SSL exception: `javax.net.ssl.SSLException: hostname in certificate didn't match: <api.forecast.io> != <*.darksky.net> OR <*.darksky.net> OR <darksky.net>`
